### PR TITLE
Basic contact us page

### DIFF
--- a/hscc/templates/contact.html
+++ b/hscc/templates/contact.html
@@ -4,6 +4,6 @@
         <h1>Contact Us</h1>
     </div>
     <div class="content">
-        <h2>Insert contact us page here</h2>
+        <p>To contact the organizers (ACM), please email us at <a href="mailto:acm@purdue.edu?Subject=HSCC%20Contact%20Us" target="_top">acm@purdue.edu</a></p>
     </div>
 {% endblock %}


### PR DESCRIPTION
It's a contact page, mailto link which autofills 'HSCC Contact Us' as the subject.
Fixes #17 
